### PR TITLE
[DO NOT MERGE] use old go1.22 for route envoy filter

### DIFF
--- a/go-routesapi/go.mod
+++ b/go-routesapi/go.mod
@@ -1,6 +1,8 @@
 module github.com/signadot/routesapi/go-routesapi
 
-go 1.23
+go 1.22.0
+
+toolchain go1.23.2
 
 require (
 	google.golang.org/grpc v1.60.0


### PR DESCRIPTION
This is just to keep a branch open for use with the route envoy filter which needs go1.22
